### PR TITLE
Remove an old require_once reference to legacy API

### DIFF
--- a/serverstatus/class.serverstatus.php
+++ b/serverstatus/class.serverstatus.php
@@ -4,7 +4,6 @@
     use Swagger\Client\ApiException;
     
     if(!defined("KB_SITE")) die ("Go Away!");
-    require_once("common/includes/api/class.serverstatus.php");
 
     class serverstatus
     {


### PR DESCRIPTION
The class.serverstatus.php file no longer exists in 4.4.x, so removing this line to prevent a breaking issue with this mod for clean installs of 4.4.x. It doesn't appear to be necessary either, tested mod on 4.4.x clean install and working as expected.